### PR TITLE
BUG FIX - Messages failing to send

### DIFF
--- a/src/example/webChat/client/src/exampleServiceDesk.ts
+++ b/src/example/webChat/client/src/exampleServiceDesk.ts
@@ -22,7 +22,6 @@ import {
   StartChatOptions,
 } from '../../../../common/types/serviceDesk';
 import { AgentProfile, ServiceDeskCallback } from '../../../../common/types/serviceDeskCallback';
-import { stringToMessageResponseFormat } from '../../../../common/utils';
 
 /**
  * This class returns startChat, endChat, sendMessageToAgent, updateState, userTyping, userReadMessages and


### PR DESCRIPTION
Messages were not being sent to Watson because of the function stringToMessageResponseFormat(). 
After removing it from the ServiceDesk, the code ran as expected.